### PR TITLE
Fix /historic route

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       - energy
     environment:
       POSTGRES_PASSWORD: password
+    volumes:
+      - postgres:/var/lib/postgresql/data
 
 networks:
   energy:
+
+volumes:
+  postgres:

--- a/service/src/app.module.ts
+++ b/service/src/app.module.ts
@@ -18,7 +18,6 @@ import { PowerSeeder } from './seeders/PowerSeeder';
   imports: [
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', '..', 'web', 'dist'),
-      renderPath: '/',
     }),
     ConfigModule.forRoot(),
     MikroOrmModule.forRoot(),


### PR DESCRIPTION
Removed "/" for static routing config. This  means you can refresh on the web UI pages but brings back the issue where the status code may not be correctly returned from Nest.