### PR TITLE
Mat toolbar-row error in console if only have one row

### DIFF
--- a/web/src/app/shared/components/navbar/navbar.component.html
+++ b/web/src/app/shared/components/navbar/navbar.component.html
@@ -1,12 +1,15 @@
-<mat-toolbar color="primary">
-  <nav>
+<!-- mobile nav -->
+<div class="md:hidden">
+  <mat-toolbar color="primary">
     <mat-toolbar-row>
       <a mat-button routerLink="/">
         <mat-icon aria-label="lightning-bolt">bolt</mat-icon>
         <span>Energy Supply & Demand</span>
       </a>
+    </mat-toolbar-row>
+    <mat-toolbar-row>
       <a
-        class="invisible md:visible"
+        class="flex-grow"
         mat-button
         [routerLink]="['/']"
         [routerLinkActiveOptions]="{ exact: true }"
@@ -14,33 +17,37 @@
         >Live Data</a
       >
       <a
-        class="invisible md:visible"
+        class="flex-grow"
         mat-button
         [routerLink]="['/historic']"
         routerLinkActive="navbar-link-active"
         >Historic Data</a
       >
     </mat-toolbar-row>
+  </mat-toolbar>
+</div>
+<!-- ./mobile nav -->
 
-    <div class="md:hidden">
-      <mat-toolbar-row>
-        <a
-          class="flex-grow"
-          mat-button
-          [routerLink]="['/']"
-          [routerLinkActiveOptions]="{ exact: true }"
-          routerLinkActive="navbar-link-active"
-          >Live Data2</a
-        >
-
-        <a
-          class="flex-grow"
-          mat-button
-          [routerLink]="['/historic']"
-          routerLinkActive="navbar-link-active"
-          >Historic Data2</a
-        >
-      </mat-toolbar-row>
-    </div>
-  </nav>
-</mat-toolbar>
+<!-- desktop nav -->
+<div class="hidden md:block">
+  <mat-toolbar color="primary">
+    <a mat-button routerLink="/">
+      <mat-icon aria-label="lightning-bolt">bolt</mat-icon>
+      <span>Energy Supply & Demand</span>
+    </a>
+    <a
+      mat-button
+      [routerLink]="['/']"
+      [routerLinkActiveOptions]="{ exact: true }"
+      routerLinkActive="navbar-link-active"
+      >Live Data</a
+    >
+    <a
+      mat-button
+      [routerLink]="['/historic']"
+      routerLinkActive="navbar-link-active"
+      >Historic Data</a
+    >
+  </mat-toolbar>
+</div>
+<!-- ./desktop nav -->


### PR DESCRIPTION
Mat Toolbar Row complained when you only had one toolbar row. You need to have none (i.e. just a mat-toolbar) or 2 or more. Refactored the toolbar component to remove this warning/error