### PR TITLE
Add data aggregation methods to data service

### DIFF
--- a/service/src/data/data.controller.ts
+++ b/service/src/data/data.controller.ts
@@ -7,10 +7,6 @@ import {
   Query,
 } from '@nestjs/common';
 import { subDays, subHours, subWeeks } from 'date-fns';
-import { DataFact } from '../entities/DataFact.entity';
-import { FuelDimension } from '../entities/FuelDimension.entity';
-import { PowerDimension } from '../entities/PowerDimension.entity';
-import { RegionDimension } from '../entities/RegionDimension.entity';
 import { FuelService } from '../fuel/fuel.service';
 import { PowerService } from '../power/power.service';
 import { RegionService } from '../region/region.service';
@@ -223,56 +219,5 @@ export class DataController {
       default:
         throw new BadRequestException('Invalid period');
     }
-
-    // TODO: re-aggregate the data for different periods
-
-    // const dataDto: DataDto = data.reduce(
-    //   (dto: DataDto, df: DataFact) => {
-    //     // add meta data if it does not exist already
-    //     if (!dto.metadata.fuels.includes(df.fuel)) {
-    //       dto.metadata.fuels.push(df.fuel);
-    //     }
-
-    //     if (!dto.metadata.power.includes(df.power)) {
-    //       dto.metadata.power.push(df.power);
-    //     }
-
-    //     if (!dto.metadata.regions.includes(df.region)) {
-    //       dto.metadata.regions.push(df.region);
-    //     }
-
-    //     // add data point
-    //     dto.data.push({
-    //       fuelId: df.fuel.id,
-    //       powerId: df.power.id,
-    //       regionId: df.region.id,
-    //       timestamp: df.timestamp,
-    //       value: df.value,
-    //     });
-
-    //     return dto;
-    //   },
-    //   {
-    //     metadata: {
-    //       fuels: [],
-    //       regions: [],
-    //       power: [],
-    //     },
-    //     data: [],
-    //   },
-    // );
-
-    // return dataDto;
-
-    // return {
-    //   metadata: {
-    //     fuels: [], //Array.from(fuels).sort((a, b) => a.name.localeCompare(b.name)),
-    //     regions: [], // Array.from(regions).sort((a, b) =>
-    //     //   a.name.localeCompare(b.name),
-    //     // ),
-    //     power: [], //Array.from(power).sort((a, b) => a.name.localeCompare(b.name)),
-    //   },
-    //   data: dataPoints,
-    // };
   }
 }

--- a/service/src/data/data.controller.ts
+++ b/service/src/data/data.controller.ts
@@ -105,14 +105,14 @@ export class DataController {
         regionId: number;
         powerId: number;
         timestamp: Date;
-        value: number;
+        value: number | string;
       }[],
     ): DataDto => {
       const dataDto: DataDto = input.reduce(
         (dto: DataDto, input) => {
           const f = fuels.find((x) => x.id === input.fuelId);
           const r = regions.find((x) => x.id === input.regionId);
-          const p = powers.find((x) => x.id === powerId);
+          const p = powers.find((x) => x.id === input.powerId);
 
           // add meta data if it does not exist already
           if (!dto.metadata.fuels.includes(f)) {
@@ -133,7 +133,10 @@ export class DataController {
             powerId: input.powerId,
             regionId: input.regionId,
             timestamp: input.timestamp,
-            value: input.value,
+            value:
+              typeof input.value === 'string'
+                ? parseFloat(input.value)
+                : input.value,
           });
 
           return dto;
@@ -180,6 +183,43 @@ export class DataController {
           powerId,
         });
         return mapToDto(fiveMinData);
+      case '15Minutes':
+        const fifteenMinData =
+          await this.dataService.findDataRange15MinutePeriod({
+            startDate,
+            endDate,
+            regionId,
+            fuelId,
+            powerId,
+          });
+        return mapToDto(fifteenMinData);
+      case '1Hour':
+        const oneHourData = await this.dataService.findDataRange1HourPeriod({
+          startDate,
+          endDate,
+          regionId,
+          fuelId,
+          powerId,
+        });
+        return mapToDto(oneHourData);
+      case '6Hours':
+        const sixHourData = await this.dataService.findDataRange6HourPeriod({
+          startDate,
+          endDate,
+          regionId,
+          fuelId,
+          powerId,
+        });
+        return mapToDto(sixHourData);
+      case '1Day':
+        const oneDayData = await this.dataService.findDataRange1DayPeriod({
+          startDate,
+          endDate,
+          regionId,
+          fuelId,
+          powerId,
+        });
+        return mapToDto(oneDayData);
       default:
         throw new BadRequestException('Invalid period');
     }

--- a/service/src/data/data.controller.ts
+++ b/service/src/data/data.controller.ts
@@ -11,6 +11,9 @@ import { DataFact } from '../entities/DataFact.entity';
 import { FuelDimension } from '../entities/FuelDimension.entity';
 import { PowerDimension } from '../entities/PowerDimension.entity';
 import { RegionDimension } from '../entities/RegionDimension.entity';
+import { FuelService } from '../fuel/fuel.service';
+import { PowerService } from '../power/power.service';
+import { RegionService } from '../region/region.service';
 import { DataService } from './data.service';
 import { DataDto } from './dto/data.dto';
 
@@ -36,7 +39,12 @@ type Period =
 export class DataController {
   private readonly logger = new Logger(DataController.name);
 
-  constructor(private readonly dataService: DataService) {}
+  constructor(
+    private readonly dataService: DataService,
+    private readonly fuelService: FuelService,
+    private readonly powerService: PowerService,
+    private readonly regionService: RegionService,
+  ) {}
 
   @Get('/timerange/:timerange/period/:period')
   async findData(
@@ -45,9 +53,15 @@ export class DataController {
     @Query('fuel') fuel: string,
     @Query('region') region: string,
     @Query('power') power: string,
-  ): Promise<DataDto> {
+  ) {
     if (!timeRange) throw new BadRequestException('Time range cannot be null');
     if (!period) throw new BadRequestException('Period cannot be null');
+
+    const [fuels, regions, powers] = await Promise.all([
+      this.fuelService.findAll(),
+      this.regionService.findAll(),
+      this.powerService.findAll(),
+    ]);
 
     const regionId = region && parseInt(region);
     const powerId = power && parseInt(power);
@@ -81,58 +95,134 @@ export class DataController {
       case '2Weeks':
         startDate = subWeeks(endDate, 2);
         break;
-
       default:
         throw new BadRequestException('Invalid time range');
     }
 
-    const data = await this.dataService.findDataRange({
-      startDate,
-      endDate,
-      regionId,
-      fuelId,
-      powerId,
-    });
+    const mapToDto = (
+      input: {
+        fuelId: number;
+        regionId: number;
+        powerId: number;
+        timestamp: Date;
+        value: number;
+      }[],
+    ): DataDto => {
+      const dataDto: DataDto = input.reduce(
+        (dto: DataDto, input) => {
+          const f = fuels.find((x) => x.id === input.fuelId);
+          const r = regions.find((x) => x.id === input.regionId);
+          const p = powers.find((x) => x.id === powerId);
+
+          // add meta data if it does not exist already
+          if (!dto.metadata.fuels.includes(f)) {
+            dto.metadata.fuels.push(f);
+          }
+
+          if (!dto.metadata.power.includes(p)) {
+            dto.metadata.power.push(p);
+          }
+
+          if (!dto.metadata.regions.includes(r)) {
+            dto.metadata.regions.push(r);
+          }
+
+          // add data point
+          dto.data.push({
+            fuelId: input.fuelId,
+            powerId: input.powerId,
+            regionId: input.regionId,
+            timestamp: input.timestamp,
+            value: input.value,
+          });
+
+          return dto;
+        },
+        {
+          metadata: {
+            fuels: [],
+            regions: [],
+            power: [],
+          },
+          data: [],
+        },
+      );
+
+      return dataDto;
+    };
+
+    switch (period) {
+      case '1Minute':
+        const oneMinData = (
+          await this.dataService.findDataRange1MinutePeriod({
+            startDate,
+            endDate,
+            regionId,
+            fuelId,
+            powerId,
+          })
+        ).map((x) => {
+          return {
+            fuelId: x.fuel,
+            regionId: x.region,
+            powerId: x.power,
+            timestamp: x.timestamp,
+            value: x.value,
+          };
+        });
+        return mapToDto(oneMinData);
+      case '5Minutes':
+        const fiveMinData = await this.dataService.findDataRange5MinutePeriod({
+          startDate,
+          endDate,
+          regionId,
+          fuelId,
+          powerId,
+        });
+        return mapToDto(fiveMinData);
+      default:
+        throw new BadRequestException('Invalid period');
+    }
 
     // TODO: re-aggregate the data for different periods
 
-    const dataDto: DataDto = data.reduce(
-      (dto: DataDto, df: DataFact) => {
-        // add meta data if it does not exist already
-        if (!dto.metadata.fuels.includes(df.fuel)) {
-          dto.metadata.fuels.push(df.fuel);
-        }
+    // const dataDto: DataDto = data.reduce(
+    //   (dto: DataDto, df: DataFact) => {
+    //     // add meta data if it does not exist already
+    //     if (!dto.metadata.fuels.includes(df.fuel)) {
+    //       dto.metadata.fuels.push(df.fuel);
+    //     }
 
-        if (!dto.metadata.power.includes(df.power)) {
-          dto.metadata.power.push(df.power);
-        }
+    //     if (!dto.metadata.power.includes(df.power)) {
+    //       dto.metadata.power.push(df.power);
+    //     }
 
-        if (!dto.metadata.regions.includes(df.region)) {
-          dto.metadata.regions.push(df.region);
-        }
+    //     if (!dto.metadata.regions.includes(df.region)) {
+    //       dto.metadata.regions.push(df.region);
+    //     }
 
-        // add data point
-        dto.data.push({
-          fuelId: df.fuel.id,
-          powerId: df.power.id,
-          regionId: df.region.id,
-          timestamp: df.timestamp,
-          value: df.value,
-        });
+    //     // add data point
+    //     dto.data.push({
+    //       fuelId: df.fuel.id,
+    //       powerId: df.power.id,
+    //       regionId: df.region.id,
+    //       timestamp: df.timestamp,
+    //       value: df.value,
+    //     });
 
-        return dto;
-      },
-      {
-        metadata: {
-          fuels: [],
-          regions: [],
-          power: [],
-        },
-        data: [],
-      },
-    );
+    //     return dto;
+    //   },
+    //   {
+    //     metadata: {
+    //       fuels: [],
+    //       regions: [],
+    //       power: [],
+    //     },
+    //     data: [],
+    //   },
+    // );
 
-    return dataDto;
+    // return dataDto;
 
     // return {
     //   metadata: {

--- a/service/src/data/data.module.ts
+++ b/service/src/data/data.module.ts
@@ -6,9 +6,15 @@ import { DataFact } from '../entities/DataFact.entity';
 import { DataGateway } from './data.gateway';
 import { FuelModule } from '../fuel/fuel.module';
 import { RegionModule } from '../region/region.module';
+import { PowerModule } from '../power/power.module';
 
 @Module({
-  imports: [MikroOrmModule.forFeature([DataFact]), FuelModule, RegionModule],
+  imports: [
+    MikroOrmModule.forFeature([DataFact]),
+    FuelModule,
+    RegionModule,
+    PowerModule,
+  ],
   controllers: [DataController],
   providers: [DataService, DataGateway],
 })

--- a/service/src/data/data.service.ts
+++ b/service/src/data/data.service.ts
@@ -118,6 +118,18 @@ export class DataService {
         { time: { twelfthOfHour: QueryOrder.ASC } },
       ]);
 
+    if (args.fuelId) {
+      qb.andWhere({ fuel: args.fuelId });
+    }
+
+    if (args.powerId) {
+      qb.andWhere({ power: args.powerId });
+    }
+
+    if (args.regionId) {
+      qb.andWhere({ region: args.regionId });
+    }
+
     return qb.execute();
   }
 
@@ -178,6 +190,18 @@ export class DataService {
         { time: { quarterOfHour: QueryOrder.ASC } },
       ]);
 
+    if (args.fuelId) {
+      qb.andWhere({ fuel: args.fuelId });
+    }
+
+    if (args.powerId) {
+      qb.andWhere({ power: args.powerId });
+    }
+
+    if (args.regionId) {
+      qb.andWhere({ region: args.regionId });
+    }
+
     return qb.execute();
   }
 
@@ -233,6 +257,18 @@ export class DataService {
         { date: { dayOfMonth: QueryOrder.ASC } },
         { time: { hour: QueryOrder.ASC } },
       ]);
+
+    if (args.fuelId) {
+      qb.andWhere({ fuel: args.fuelId });
+    }
+
+    if (args.powerId) {
+      qb.andWhere({ power: args.powerId });
+    }
+
+    if (args.regionId) {
+      qb.andWhere({ region: args.regionId });
+    }
 
     return qb.execute();
   }
@@ -290,6 +326,18 @@ export class DataService {
         { time: { quarterOfDay: QueryOrder.ASC } },
       ]);
 
+    if (args.fuelId) {
+      qb.andWhere({ fuel: args.fuelId });
+    }
+
+    if (args.powerId) {
+      qb.andWhere({ power: args.powerId });
+    }
+
+    if (args.regionId) {
+      qb.andWhere({ region: args.regionId });
+    }
+
     return qb.execute();
   }
 
@@ -340,6 +388,18 @@ export class DataService {
         { date: { monthNumber: QueryOrder.ASC } },
         { date: { dayOfMonth: QueryOrder.ASC } },
       ]);
+
+    if (args.fuelId) {
+      qb.andWhere({ fuel: args.fuelId });
+    }
+
+    if (args.powerId) {
+      qb.andWhere({ power: args.powerId });
+    }
+
+    if (args.regionId) {
+      qb.andWhere({ region: args.regionId });
+    }
 
     return qb.execute();
   }

--- a/service/src/data/data.service.ts
+++ b/service/src/data/data.service.ts
@@ -1,3 +1,4 @@
+import { QueryOrder } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { EntityRepository } from '@mikro-orm/postgresql';
 import { Injectable, Logger } from '@nestjs/common';
@@ -12,18 +13,34 @@ export class DataService {
     private dataFactRepository: EntityRepository<DataFact>,
   ) {}
 
-  async findDataRange(args: {
+  /**
+   * Find data range with 1 minute data period
+   * @param args
+   * @returns
+   */
+  async findDataRange1MinutePeriod(args: {
     startDate: Date;
     endDate: Date;
     fuelId?: number;
     powerId?: number;
     regionId?: number;
-  }) {
-    this.logger.log('Find data range');
+  }): Promise<
+    {
+      uuid: string;
+      timestamp: Date;
+      value: number;
+      fuel: number;
+      region: number;
+      power: number;
+      date: number;
+      time: number;
+    }[]
+  > {
+    this.logger.log('Find data range with 1 minute period');
 
     const qb = this.dataFactRepository
       .qb()
-      .select('uuid')
+      .select('*')
       .where({ timestamp: { $gte: args.startDate } })
       .andWhere({ timestamp: { $lte: args.endDate } });
 
@@ -39,16 +56,67 @@ export class DataService {
       qb.andWhere({ region: args.regionId });
     }
 
-    const uuids = (await qb.execute()).map((x) => x.uuid);
+    qb.orderBy({ timestamp: QueryOrder.ASC });
 
-    return this.dataFactRepository.find(
-      {
-        uuid: { $in: uuids },
-      },
-      {
-        populate: ['fuel', 'region', 'power'],
-        orderBy: { timestamp: 'asc' },
-      },
-    );
+    return qb.execute();
+  }
+
+  async findDataRange5MinutePeriod(args: {
+    startDate: Date;
+    endDate: Date;
+    fuelId?: number;
+    powerId?: number;
+    regionId?: number;
+  }): Promise<
+    {
+      year: number;
+      monthNumber: number;
+      dayOfMonth: number;
+      hour: number;
+      twelfthOfHour: number;
+      fuelId: number;
+      regionId: number;
+      powerId: number;
+      timestamp: Date;
+      value: number;
+    }[]
+  > {
+    this.logger.log('Find data range with 1 minute period');
+
+    const qb = this.dataFactRepository
+      .qb('df')
+      .select([
+        'dd.year as year',
+        'dd.month_number as monthNumber',
+        'dd.day_of_month as dayOfMonth',
+        'td.hour as hour',
+        'td.twelfth_of_hour as twelfthOfHour',
+        'df.fuel_id as fuelId',
+        'df.region_id as regionId',
+        'df.power_id as powerId',
+        'min(timestamp) as timestamp',
+        'avg(value) as value',
+      ])
+      .join('df.date', 'dd')
+      .join('df.time', 'td')
+      .groupBy([
+        'dd.year',
+        'dd.month_number',
+        'dd.day_of_month',
+        'td.hour',
+        'td.twelfth_of_hour',
+        'df.fuel_id',
+        'df.region_id',
+        'df.power_id',
+      ])
+      .orderBy([
+        { date: { year: QueryOrder.ASC } },
+        { date: { monthNumber: QueryOrder.ASC } },
+        { date: { dayOfMonth: QueryOrder.ASC } },
+        { time: { hour: QueryOrder.ASC } },
+        { time: { twelfthOfHour: QueryOrder.ASC } },
+      ]);
+
+    return qb.execute();
   }
 }

--- a/service/src/data/data.service.ts
+++ b/service/src/data/data.service.ts
@@ -13,11 +13,6 @@ export class DataService {
     private dataFactRepository: EntityRepository<DataFact>,
   ) {}
 
-  /**
-   * Find data range with 1 minute data period
-   * @param args
-   * @returns
-   */
   async findDataRange1MinutePeriod(args: {
     startDate: Date;
     endDate: Date;
@@ -99,7 +94,6 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
-      // todo: add where clause
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -171,7 +165,6 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
-      // todo: add where clause
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -241,7 +234,6 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
-      // todo: add where clause
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -309,7 +301,6 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
-      // todo: add where clause
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -374,7 +365,6 @@ export class DataService {
         'avg(value) as value',
       ])
       .join('df.date', 'dd')
-      // todo: add where clause
       .groupBy([
         'dd.year',
         'dd.month_number',

--- a/service/src/data/data.service.ts
+++ b/service/src/data/data.service.ts
@@ -78,10 +78,10 @@ export class DataService {
       regionId: number;
       powerId: number;
       timestamp: Date;
-      value: number;
+      value: string;
     }[]
   > {
-    this.logger.log('Find data range with 1 minute period');
+    this.logger.log('Find data range with 5 minute period');
 
     const qb = this.dataFactRepository
       .qb('df')
@@ -99,6 +99,7 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
+      // todo: add where clause
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -115,6 +116,229 @@ export class DataService {
         { date: { dayOfMonth: QueryOrder.ASC } },
         { time: { hour: QueryOrder.ASC } },
         { time: { twelfthOfHour: QueryOrder.ASC } },
+      ]);
+
+    return qb.execute();
+  }
+
+  async findDataRange15MinutePeriod(args: {
+    startDate: Date;
+    endDate: Date;
+    fuelId?: number;
+    powerId?: number;
+    regionId?: number;
+  }): Promise<
+    {
+      year: number;
+      monthNumber: number;
+      dayOfMonth: number;
+      hour: number;
+      quarterOfHour: number;
+      fuelId: number;
+      regionId: number;
+      powerId: number;
+      timestamp: Date;
+      value: string;
+    }[]
+  > {
+    this.logger.log('Find data range with 15 minute period');
+
+    const qb = this.dataFactRepository
+      .qb('df')
+      .select([
+        'dd.year as year',
+        'dd.month_number as monthNumber',
+        'dd.day_of_month as dayOfMonth',
+        'td.hour as hour',
+        'td.quarter_of_hour as quarterOfHour',
+        'df.fuel_id as fuelId',
+        'df.region_id as regionId',
+        'df.power_id as powerId',
+        'min(timestamp) as timestamp',
+        'avg(value) as value',
+      ])
+      .join('df.date', 'dd')
+      .join('df.time', 'td')
+      // todo: add where clause
+      .groupBy([
+        'dd.year',
+        'dd.month_number',
+        'dd.day_of_month',
+        'td.hour',
+        'td.quarter_of_hour',
+        'df.fuel_id',
+        'df.region_id',
+        'df.power_id',
+      ])
+      .orderBy([
+        { date: { year: QueryOrder.ASC } },
+        { date: { monthNumber: QueryOrder.ASC } },
+        { date: { dayOfMonth: QueryOrder.ASC } },
+        { time: { hour: QueryOrder.ASC } },
+        { time: { quarterOfHour: QueryOrder.ASC } },
+      ]);
+
+    return qb.execute();
+  }
+
+  async findDataRange1HourPeriod(args: {
+    startDate: Date;
+    endDate: Date;
+    fuelId?: number;
+    powerId?: number;
+    regionId?: number;
+  }): Promise<
+    {
+      year: number;
+      monthNumber: number;
+      dayOfMonth: number;
+      hour: number;
+      fuelId: number;
+      regionId: number;
+      powerId: number;
+      timestamp: Date;
+      value: string;
+    }[]
+  > {
+    this.logger.log('Find data range with 1 hour period');
+
+    const qb = this.dataFactRepository
+      .qb('df')
+      .select([
+        'dd.year as year',
+        'dd.month_number as monthNumber',
+        'dd.day_of_month as dayOfMonth',
+        'td.hour as hour',
+        'df.fuel_id as fuelId',
+        'df.region_id as regionId',
+        'df.power_id as powerId',
+        'min(timestamp) as timestamp',
+        'avg(value) as value',
+      ])
+      .join('df.date', 'dd')
+      .join('df.time', 'td')
+      // todo: add where clause
+      .groupBy([
+        'dd.year',
+        'dd.month_number',
+        'dd.day_of_month',
+        'td.hour',
+        'df.fuel_id',
+        'df.region_id',
+        'df.power_id',
+      ])
+      .orderBy([
+        { date: { year: QueryOrder.ASC } },
+        { date: { monthNumber: QueryOrder.ASC } },
+        { date: { dayOfMonth: QueryOrder.ASC } },
+        { time: { hour: QueryOrder.ASC } },
+      ]);
+
+    return qb.execute();
+  }
+
+  async findDataRange6HourPeriod(args: {
+    startDate: Date;
+    endDate: Date;
+    fuelId?: number;
+    powerId?: number;
+    regionId?: number;
+  }): Promise<
+    {
+      year: number;
+      monthNumber: number;
+      dayOfMonth: number;
+      quaterOfHour: number;
+      fuelId: number;
+      regionId: number;
+      powerId: number;
+      timestamp: Date;
+      value: string;
+    }[]
+  > {
+    this.logger.log('Find data range with 6 hour period');
+
+    const qb = this.dataFactRepository
+      .qb('df')
+      .select([
+        'dd.year as year',
+        'dd.month_number as monthNumber',
+        'dd.day_of_month as dayOfMonth',
+        'td.quarter_of_day as quarterOfDay',
+        'df.fuel_id as fuelId',
+        'df.region_id as regionId',
+        'df.power_id as powerId',
+        'min(timestamp) as timestamp',
+        'avg(value) as value',
+      ])
+      .join('df.date', 'dd')
+      .join('df.time', 'td')
+      // todo: add where clause
+      .groupBy([
+        'dd.year',
+        'dd.month_number',
+        'dd.day_of_month',
+        'td.quarter_of_day',
+        'df.fuel_id',
+        'df.region_id',
+        'df.power_id',
+      ])
+      .orderBy([
+        { date: { year: QueryOrder.ASC } },
+        { date: { monthNumber: QueryOrder.ASC } },
+        { date: { dayOfMonth: QueryOrder.ASC } },
+        { time: { quarterOfDay: QueryOrder.ASC } },
+      ]);
+
+    return qb.execute();
+  }
+
+  async findDataRange1DayPeriod(args: {
+    startDate: Date;
+    endDate: Date;
+    fuelId?: number;
+    powerId?: number;
+    regionId?: number;
+  }): Promise<
+    {
+      year: number;
+      monthNumber: number;
+      dayOfMonth: number;
+      fuelId: number;
+      regionId: number;
+      powerId: number;
+      timestamp: Date;
+      value: string;
+    }[]
+  > {
+    this.logger.log('Find data range with 1 day period');
+
+    const qb = this.dataFactRepository
+      .qb('df')
+      .select([
+        'dd.year as year',
+        'dd.month_number as monthNumber',
+        'dd.day_of_month as dayOfMonth',
+        'df.fuel_id as fuelId',
+        'df.region_id as regionId',
+        'df.power_id as powerId',
+        'min(timestamp) as timestamp',
+        'avg(value) as value',
+      ])
+      .join('df.date', 'dd')
+      // todo: add where clause
+      .groupBy([
+        'dd.year',
+        'dd.month_number',
+        'dd.day_of_month',
+        'df.fuel_id',
+        'df.region_id',
+        'df.power_id',
+      ])
+      .orderBy([
+        { date: { year: QueryOrder.ASC } },
+        { date: { monthNumber: QueryOrder.ASC } },
+        { date: { dayOfMonth: QueryOrder.ASC } },
       ]);
 
     return qb.execute();


### PR DESCRIPTION
Add functionality to be able to get the following aggregated data:
* 5 Minutes
* 15 Minutes
* 1 Hour
* 6 Hours
* 1 Day

Currently this just get's the AVG of the values and returns the MIN of the timestamp for the period. The aggregations are also done in UTC time. So This isn't a factor for anything less than a day as a 6 hour period's min timestamp will be converted to local time. However the daily aggregation's value is calculated over a UTC day (not midnight to midnight in the data's local timezone). 

Examples are given in in this issue [#20](https://github.com/michaelgambold/energy-supply-demand/issues/20)