### PR TITLE
Start/End timestamps not applying to 5 min + periods

### DIFF
--- a/service/src/data/data.controller.ts
+++ b/service/src/data/data.controller.ts
@@ -6,7 +6,7 @@ import {
   Param,
   Query,
 } from '@nestjs/common';
-import { subDays, subHours, subWeeks } from 'date-fns';
+import { isAfter, isBefore, subDays, subHours, subWeeks } from 'date-fns';
 import { FuelService } from '../fuel/fuel.service';
 import { PowerService } from '../power/power.service';
 import { RegionService } from '../region/region.service';
@@ -123,6 +123,21 @@ export class DataController {
             dto.metadata.regions.push(r);
           }
 
+          // update start/end/record count
+          if (!dto.startTimestamp) {
+            dto.startTimestamp = input.timestamp.toISOString();
+          } else if (isBefore(input.timestamp, new Date(dto.startTimestamp))) {
+            dto.startTimestamp = input.timestamp.toISOString();
+          }
+
+          if (!dto.endTimestamp) {
+            dto.endTimestamp = input.timestamp.toISOString();
+          } else if (isAfter(input.timestamp, new Date(dto.endTimestamp))) {
+            dto.endTimestamp = input.timestamp.toISOString();
+          }
+
+          dto.recordCount = dto.recordCount + 1;
+
           // add data point
           dto.data.push({
             fuelId: input.fuelId,
@@ -138,6 +153,9 @@ export class DataController {
           return dto;
         },
         {
+          startTimestamp: '',
+          endTimestamp: '',
+          recordCount: 0,
           metadata: {
             fuels: [],
             regions: [],

--- a/service/src/data/data.service.ts
+++ b/service/src/data/data.service.ts
@@ -94,6 +94,8 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
+      .where({ timestamp: { $gte: args.startDate } })
+      .andWhere({ timestamp: { $lte: args.endDate } })
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -165,6 +167,8 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
+      .where({ timestamp: { $gte: args.startDate } })
+      .andWhere({ timestamp: { $lte: args.endDate } })
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -234,6 +238,8 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
+      .where({ timestamp: { $gte: args.startDate } })
+      .andWhere({ timestamp: { $lte: args.endDate } })
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -301,6 +307,8 @@ export class DataService {
       ])
       .join('df.date', 'dd')
       .join('df.time', 'td')
+      .where({ timestamp: { $gte: args.startDate } })
+      .andWhere({ timestamp: { $lte: args.endDate } })
       .groupBy([
         'dd.year',
         'dd.month_number',
@@ -365,6 +373,8 @@ export class DataService {
         'avg(value) as value',
       ])
       .join('df.date', 'dd')
+      .where({ timestamp: { $gte: args.startDate } })
+      .andWhere({ timestamp: { $lte: args.endDate } })
       .groupBy([
         'dd.year',
         'dd.month_number',

--- a/service/src/data/dto/data.dto.ts
+++ b/service/src/data/dto/data.dto.ts
@@ -1,4 +1,7 @@
 export class DataDto {
+  startTimestamp: string;
+  endTimestamp: string;
+  recordCount: number;
   metadata: {
     fuels: Fuel[];
     regions: Region[];

--- a/web/src/app/shared/models/data.ts
+++ b/web/src/app/shared/models/data.ts
@@ -3,6 +3,9 @@ import { Power } from './power';
 import { Region } from './region';
 
 export interface Data {
+  startTimestamp: string;
+  endTimestamp: string;
+  recordCount: number;
   metadata: {
     fuels: Fuel[];
     power: Power[];

--- a/web/src/app/shared/services/data.service.ts
+++ b/web/src/app/shared/services/data.service.ts
@@ -34,10 +34,7 @@ export class DataService {
     powerId?: number;
     regionId?: number;
   }): Observable<Data> {
-    const urlParams = new URLSearchParams({
-      timerange: args.timeRange,
-      period: args.period,
-    });
+    const urlParams = new URLSearchParams();
 
     if (args.fuelId) {
       urlParams.append('fuel', args.fuelId.toString());


### PR DESCRIPTION
When performing the group by queries the start/end timestamps were not applied to the DB queries.

Extra properties have been added to the Data DTO for `startTimestamp`, `endTimestamp` and `recordCount` to help diagnose these issues in the future.