### PR TITLE
Improve group by query performance

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -10,6 +10,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "migration:create": "npx mikro-orm migration:create",
+    "migration:down": "npx mikro-orm migration:down",
     "migration:up": "npx mikro-orm migration:up",
     "seeder:run": "npx mikro-orm seeder:run",
     "start": "nest start",

--- a/service/src/entities/DataFact.entity.ts
+++ b/service/src/entities/DataFact.entity.ts
@@ -13,35 +13,43 @@ import { PowerDimension } from './PowerDimension.entity';
 import { RegionDimension } from './RegionDimension.entity';
 import { TimeDimension } from './TimeDimension.entity';
 
+@Index({
+  name: 'data_fact_dimensions_idx',
+  properties: ['fuel', 'region', 'power', 'date', 'time'],
+})
+@Index({
+  name: 'data_fact_date_time_idx',
+  properties: ['date', 'time'],
+})
 @Entity()
 export class DataFact {
   @PrimaryKey()
   uuid = v4();
 
-  @Index({ name: 'timestamp_index' })
+  @Index({ name: 'data_fact_timestamp_idx' })
   @Property()
   timestamp: Date;
 
   @Property()
   value: number;
 
-  @Index({ name: 'fuel_index' })
+  @Index({ name: 'data_fact_fuel_idx' })
   @ManyToOne()
   fuel!: FuelDimension;
 
-  @Index({ name: 'region_index' })
+  @Index({ name: 'data_fact_region_idx' })
   @ManyToOne()
   region!: RegionDimension;
 
-  @Index({ name: 'power_index' })
+  @Index({ name: 'data_fact_power_idx' })
   @ManyToOne()
   power!: PowerDimension;
 
-  @Index({ name: 'date_index' })
+  @Index({ name: 'data_fact_date_idx' })
   @ManyToOne()
   date!: DateDimension;
 
-  @Index({ name: 'time_index' })
+  @Index({ name: 'data_fact_time_idx' })
   @ManyToOne()
   time!: TimeDimension;
 }

--- a/service/src/entities/DateDimension.entity.ts
+++ b/service/src/entities/DateDimension.entity.ts
@@ -1,5 +1,9 @@
-import { Entity, PrimaryKey, Property, types } from '@mikro-orm/core';
+import { Entity, Index, PrimaryKey, Property, types } from '@mikro-orm/core';
 
+@Index({
+  name: 'date_dimension_year_month_day_idx',
+  properties: ['year', 'monthNumber', 'dayOfMonth'],
+})
 @Entity()
 export class DateDimension {
   @PrimaryKey()

--- a/service/src/entities/TimeDimension.entity.ts
+++ b/service/src/entities/TimeDimension.entity.ts
@@ -1,5 +1,13 @@
-import { Entity, PrimaryKey, Property, types } from '@mikro-orm/core';
+import { Entity, Index, PrimaryKey, Property, types } from '@mikro-orm/core';
 
+@Index({
+  name: 'time_dimension_hour_minute_idx',
+  properties: ['hour', 'minute'],
+})
+@Index({
+  name: 'time_dimension_hour_quarter_of_hour_idx',
+  properties: ['hour', 'quarterOfHour'],
+})
 @Entity()
 export class TimeDimension {
   @PrimaryKey()
@@ -8,12 +16,14 @@ export class TimeDimension {
   @Property({ type: types.time })
   time: string;
 
+  @Index({ name: 'time_dimension_quarter_of_day_idx' })
   @Property()
   quarterOfDay: number;
 
   @Property()
   halfOfDay: number;
 
+  @Index({ name: 'time_dimension_hour_idx' })
   @Property()
   hour: number;
 

--- a/service/src/migrations/.snapshot-postgres.json
+++ b/service/src/migrations/.snapshot-postgres.json
@@ -83,6 +83,44 @@
       "schema": "public",
       "indexes": [
         {
+          "columnNames": [
+            "quarter_of_day"
+          ],
+          "composite": false,
+          "keyName": "time_dimension_quarter_of_day_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "hour"
+          ],
+          "composite": false,
+          "keyName": "time_dimension_hour_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "time_dimension_hour_quarter_of_hour_idx",
+          "columnNames": [
+            "hour",
+            "quarter_of_hour"
+          ],
+          "composite": true,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "time_dimension_hour_minute_idx",
+          "columnNames": [
+            "hour",
+            "minute"
+          ],
+          "composite": true,
+          "primary": false,
+          "unique": false
+        },
+        {
           "keyName": "time_dimension_pkey",
           "columnNames": [
             "id"
@@ -357,6 +395,17 @@
       "schema": "public",
       "indexes": [
         {
+          "keyName": "date_dimension_year_month_day_idx",
+          "columnNames": [
+            "year",
+            "month_number",
+            "day_of_month"
+          ],
+          "composite": true,
+          "primary": false,
+          "unique": false
+        },
+        {
           "keyName": "date_dimension_pkey",
           "columnNames": [
             "id"
@@ -453,7 +502,7 @@
             "timestamp"
           ],
           "composite": false,
-          "keyName": "timestamp_index",
+          "keyName": "data_fact_timestamp_idx",
           "primary": false,
           "unique": false
         },
@@ -462,7 +511,7 @@
             "fuel_id"
           ],
           "composite": false,
-          "keyName": "fuel_index",
+          "keyName": "data_fact_fuel_idx",
           "primary": false,
           "unique": false
         },
@@ -471,7 +520,7 @@
             "region_id"
           ],
           "composite": false,
-          "keyName": "region_index",
+          "keyName": "data_fact_region_idx",
           "primary": false,
           "unique": false
         },
@@ -480,7 +529,7 @@
             "power_id"
           ],
           "composite": false,
-          "keyName": "power_index",
+          "keyName": "data_fact_power_idx",
           "primary": false,
           "unique": false
         },
@@ -489,7 +538,7 @@
             "date_id"
           ],
           "composite": false,
-          "keyName": "date_index",
+          "keyName": "data_fact_date_idx",
           "primary": false,
           "unique": false
         },
@@ -498,7 +547,30 @@
             "time_id"
           ],
           "composite": false,
-          "keyName": "time_index",
+          "keyName": "data_fact_time_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "data_fact_date_time_idx",
+          "columnNames": [
+            "date_id",
+            "time_id"
+          ],
+          "composite": true,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "data_fact_dimensions_idx",
+          "columnNames": [
+            "fuel_id",
+            "region_id",
+            "power_id",
+            "date_id",
+            "time_id"
+          ],
+          "composite": true,
           "primary": false,
           "unique": false
         },

--- a/service/src/migrations/Migration20220705055535.ts
+++ b/service/src/migrations/Migration20220705055535.ts
@@ -1,0 +1,41 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20220705055535 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('create index "time_dimension_quarter_of_day_idx" on "time_dimension" ("quarter_of_day");');
+    this.addSql('create index "time_dimension_hour_idx" on "time_dimension" ("hour");');
+    this.addSql('create index "time_dimension_hour_quarter_of_hour_idx" on "time_dimension" ("hour", "quarter_of_hour");');
+    this.addSql('create index "time_dimension_hour_minute_idx" on "time_dimension" ("hour", "minute");');
+
+    this.addSql('create index "date_dimension_year_month_day_idx" on "date_dimension" ("year", "month_number", "day_of_month");');
+
+    this.addSql('create index "data_fact_date_time_idx" on "data_fact" ("date_id", "time_id");');
+    this.addSql('create index "data_fact_dimensions_idx" on "data_fact" ("fuel_id", "region_id", "power_id", "date_id", "time_id");');
+    this.addSql('alter index "timestamp_index" rename to "data_fact_timestamp_idx";');
+    this.addSql('alter index "fuel_index" rename to "data_fact_fuel_idx";');
+    this.addSql('alter index "region_index" rename to "data_fact_region_idx";');
+    this.addSql('alter index "power_index" rename to "data_fact_power_idx";');
+    this.addSql('alter index "date_index" rename to "data_fact_date_idx";');
+    this.addSql('alter index "time_index" rename to "data_fact_time_idx";');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('drop index "time_dimension_quarter_of_day_idx";');
+    this.addSql('drop index "time_dimension_hour_idx";');
+    this.addSql('drop index "time_dimension_hour_quarter_of_hour_idx";');
+    this.addSql('drop index "time_dimension_hour_minute_idx";');
+
+    this.addSql('drop index "date_dimension_year_month_day_idx";');
+
+    this.addSql('drop index "data_fact_date_time_idx";');
+    this.addSql('drop index "data_fact_dimensions_idx";');
+    this.addSql('alter index "data_fact_timestamp_idx" rename to "timestamp_index";');
+    this.addSql('alter index "data_fact_fuel_idx" rename to "fuel_index";');
+    this.addSql('alter index "data_fact_region_idx" rename to "region_index";');
+    this.addSql('alter index "data_fact_power_idx" rename to "power_index";');
+    this.addSql('alter index "data_fact_date_idx" rename to "date_index";');
+    this.addSql('alter index "data_fact_time_idx" rename to "time_index";');
+  }
+
+}


### PR DESCRIPTION
Improve query performance with DB indexes. Was fine in dev env but really slow in prod.

In dev environment ~30 second query became 1.2 second.

If this sort of issue (i.e. with data volume becomes and issue) will need to have a dev seeder to seed lots of data into dev environment.