### PR TITLE
Add all regions tab to historic page

### DIFF
--- a/web/src/app/pages/historic-data-page/historic-data-page.component.html
+++ b/web/src/app/pages/historic-data-page/historic-data-page.component.html
@@ -55,28 +55,61 @@
     <h2>{{ selectedRegion?.name }}</h2>
     <!-- fuel filters -->
     <div class="mb-4">
-      <app-line-chart
-        *ngIf="generationData$ | async as data; else spinner"
-        [title]="'Generation'"
-        [series]="data.metadata.fuels | fuelsToLineSeries"
-        [data]="data.data | dataToLineDataPoints: 'fuel'"
-      ></app-line-chart>
+      <ng-container *ngIf="selectedRegion?.ref === 'all'">
+        <app-line-chart
+          *ngIf="generationData$ | async as data; else spinner"
+          [title]="'Generation'"
+          [series]="data.metadata.fuels | fuelsToLineSeries"
+          [data]="(data | combineRegions).data | dataToLineDataPoints: 'fuel'"
+        ></app-line-chart>
+      </ng-container>
+      <ng-container *ngIf="selectedRegion?.ref !== 'all'">
+        <app-line-chart
+          *ngIf="generationData$ | async as data; else spinner"
+          [title]="'Generation'"
+          [series]="data.metadata.fuels | fuelsToLineSeries"
+          [data]="data.data | dataToLineDataPoints: 'fuel'"
+        ></app-line-chart>
+      </ng-container>
     </div>
     <div class="mb-4">
-      <app-line-chart
-        *ngIf="fuelTypeGenerationData$ | async as data; else spinner"
-        [title]="'Generation (Green vs Fossil)'"
-        [series]="data.metadata.fuels | fuelsToLineSeries"
-        [data]="data.data | dataToLineDataPoints: 'fuel'"
-      ></app-line-chart>
+      <ng-container *ngIf="selectedRegion?.ref === 'all'">
+        <app-line-chart
+          *ngIf="fuelTypeGenerationData$ | async as data; else spinner"
+          [title]="'Generation (Green vs Fossil)'"
+          [series]="data.metadata.fuels | fuelsToLineSeries"
+          [data]="
+            (data | combineRegionsGreenFossil).data
+              | dataToLineDataPoints: 'fuel'
+          "
+        ></app-line-chart>
+      </ng-container>
+      <ng-container *ngIf="selectedRegion?.ref !== 'all'">
+        <app-line-chart
+          *ngIf="fuelTypeGenerationData$ | async as data; else spinner"
+          [title]="'Generation (Green vs Fossil)'"
+          [series]="data.metadata.fuels | fuelsToLineSeries"
+          [data]="data.data | dataToLineDataPoints: 'fuel'"
+        ></app-line-chart>
+      </ng-container>
     </div>
     <div class="mb-4">
-      <app-line-chart
-        *ngIf="demandData$ | async as data; else spinner"
-        [title]="'Demand'"
-        [series]="data.metadata.fuels | fuelsToLineSeries"
-        [data]="data.data | dataToLineDataPoints: 'fuel'"
-      ></app-line-chart>
+      <ng-container *ngIf="selectedRegion?.ref === 'all'">
+        <app-line-chart
+          *ngIf="demandData$ | async as data; else spinner"
+          [title]="'Demand'"
+          [series]="data.metadata.fuels | fuelsToLineSeries"
+          [data]="(data | combineRegions).data | dataToLineDataPoints: 'fuel'"
+        ></app-line-chart>
+      </ng-container>
+      <ng-container *ngIf="selectedRegion?.ref !== 'all'">
+        <app-line-chart
+          *ngIf="demandData$ | async as data; else spinner"
+          [title]="'Demand'"
+          [series]="data.metadata.fuels | fuelsToLineSeries"
+          [data]="data.data | dataToLineDataPoints: 'fuel'"
+        ></app-line-chart>
+      </ng-container>
     </div>
   </div>
 </ng-template>

--- a/web/src/app/pages/historic-data-page/historic-data-page.component.ts
+++ b/web/src/app/pages/historic-data-page/historic-data-page.component.ts
@@ -85,7 +85,16 @@ export class HistoricDataPageComponent implements OnInit, OnDestroy {
       this.route.queryParamMap,
     ]).subscribe(([power, regions, paramMap]) => {
       this.power = power;
-      this.regions = regions;
+      this.regions = [
+        {
+          abbreviation: 'all',
+          id: 0,
+          name: 'All',
+          ref: 'all',
+          timezone: '',
+        },
+        ...regions,
+      ];
 
       // update selections from query params if we have them
       this.selectedRegionIndex = Number(paramMap.get('tab') || 0);

--- a/web/src/app/shared/pipes/combine-regions-green-fossil.pipe.spec.ts
+++ b/web/src/app/shared/pipes/combine-regions-green-fossil.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { CombineRegionsGreenFossilPipe } from './combine-regions-green-fossil.pipe';
+
+describe('CombineRegionsGreenFossilPipe', () => {
+  it('create an instance', () => {
+    const pipe = new CombineRegionsGreenFossilPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/web/src/app/shared/pipes/combine-regions-green-fossil.pipe.ts
+++ b/web/src/app/shared/pipes/combine-regions-green-fossil.pipe.ts
@@ -1,0 +1,99 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Data, DataPoint } from '../models/data';
+
+@Pipe({
+  name: 'combineRegionsGreenFossil',
+})
+export class CombineRegionsGreenFossilPipe implements PipeTransform {
+  transform(value: Data, ...args: unknown[]): Data {
+    const dataPointMap = new Map<string, DataPoint[]>();
+
+    const greenFuel = value.metadata.fuels.find((x) => x.ref === 'green');
+    const fossilFuel = value.metadata.fuels.find((x) => x.ref === 'fossil');
+    const unknownFuel = value.metadata.fuels.find((x) => x.ref === 'unknown');
+
+    if (!greenFuel || !fossilFuel || !unknownFuel)
+      throw new Error('Failed to find fuels');
+
+    for (const dataPoint of value.data) {
+      const key = `${dataPoint.timestamp}_${dataPoint.powerId}`;
+
+      if (dataPointMap.has(key)) continue;
+
+      const greenDataPoints = value.data.filter(
+        (x) =>
+          x.timestamp === dataPoint.timestamp &&
+          x.powerId === dataPoint.powerId &&
+          x.fuelId === greenFuel.id
+      );
+      const fossilDataPoints = value.data.filter(
+        (x) =>
+          x.timestamp === dataPoint.timestamp &&
+          x.powerId === dataPoint.powerId &&
+          x.fuelId === fossilFuel.id
+      );
+      const unknownDataPoints = value.data.filter(
+        (x) =>
+          x.timestamp === dataPoint.timestamp &&
+          x.powerId === dataPoint.powerId &&
+          x.fuelId === unknownFuel.id
+      );
+
+      const greenSum = greenDataPoints.length
+        ? greenDataPoints.reduce((runningTotal, dataPoint) => {
+            return runningTotal + dataPoint.value;
+          }, 0)
+        : 0;
+      const fossilSum = fossilDataPoints.length
+        ? fossilDataPoints.reduce((runningTotal, dataPoint) => {
+            return runningTotal + dataPoint.value;
+          }, 0)
+        : 0;
+      const unknownSum = unknownDataPoints.length
+        ? unknownDataPoints.reduce((runningTotal, dataPoint) => {
+            return runningTotal + dataPoint.value;
+          }, 0)
+        : 0;
+
+      const sum = greenSum + fossilSum + unknownSum;
+
+      dataPointMap.set(key, [
+        {
+          fuelId: greenFuel.id,
+          powerId: dataPoint.powerId,
+          regionId: 0,
+          timestamp: dataPoint.timestamp,
+          value: (greenSum / sum) * 100,
+        },
+        {
+          fuelId: fossilFuel.id,
+          powerId: dataPoint.powerId,
+          regionId: 0,
+          timestamp: dataPoint.timestamp,
+          value: (fossilSum / sum) * 100,
+        },
+        {
+          fuelId: unknownFuel.id,
+          powerId: dataPoint.powerId,
+          regionId: 0,
+          timestamp: dataPoint.timestamp,
+          value: (unknownSum / sum) * 100,
+        },
+      ]);
+    }
+
+    const dataPointsArray = Array.from(dataPointMap.values()).flat();
+
+    return {
+      data: dataPointsArray,
+      endTimestamp: value.endTimestamp,
+      metadata: {
+        fuels: value.metadata.fuels,
+        power: value.metadata.power,
+        regions: [],
+      },
+      recordCount: dataPointsArray.length,
+      startTimestamp: value.startTimestamp,
+    };
+  }
+}

--- a/web/src/app/shared/pipes/combine-regions.pipe.spec.ts
+++ b/web/src/app/shared/pipes/combine-regions.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { CombineRegionsPipe } from './combine-regions.pipe';
+
+describe('CombineRegionsPipe', () => {
+  it('create an instance', () => {
+    const pipe = new CombineRegionsPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/web/src/app/shared/pipes/combine-regions.pipe.ts
+++ b/web/src/app/shared/pipes/combine-regions.pipe.ts
@@ -1,0 +1,53 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { Data, DataPoint } from '../models/data';
+
+@Pipe({
+  name: 'combineRegions',
+})
+export class CombineRegionsPipe implements PipeTransform {
+  transform(value: Data, ...args: unknown[]): Data {
+    const dataPointMap: Map<string, DataPoint> = value.data.reduce(
+      (dataPointMap, dataPoint) => {
+        const key = `${dataPoint.timestamp}_${dataPoint.fuelId}_${dataPoint.powerId}`;
+        const dp = dataPointMap.get(key);
+
+        if (dp) {
+          dataPointMap.set(key, { ...dp, value: dp.value + dataPoint.value });
+        } else {
+          dataPointMap.set(key, {
+            fuelId: dataPoint.fuelId,
+            powerId: dataPoint.powerId,
+            regionId: 0,
+            timestamp: dataPoint.timestamp,
+            value: dataPoint.value,
+          });
+        }
+
+        return dataPointMap;
+      },
+      new Map<string, DataPoint>()
+    );
+
+    const sortedDataPoints = Array.from(dataPointMap.values()).sort((a, b) => {
+      if (new Date(a.timestamp).valueOf() < new Date(b.timestamp).valueOf())
+        return -1;
+      if (new Date(a.timestamp).valueOf() > new Date(b.timestamp).valueOf())
+        return 1;
+      return 0;
+    });
+
+    const data: Data = {
+      startTimestamp: value.startTimestamp,
+      endTimestamp: value.endTimestamp,
+      recordCount: sortedDataPoints.length,
+      metadata: {
+        fuels: value.metadata.fuels,
+        power: value.metadata.power,
+        regions: [],
+      },
+      data: sortedDataPoints,
+    };
+
+    return data;
+  }
+}

--- a/web/src/app/shared/shared.module.ts
+++ b/web/src/app/shared/shared.module.ts
@@ -13,6 +13,8 @@ import { StackedBarChartComponent } from './components/stacked-bar-chart/stacked
 import { RegionsToStackedBarCategoriesPipe } from './pipes/regions-to-stacked-bar-categories';
 import { FuelsToStackedBarSeriesPipe } from './pipes/fuels-to-stacked-bar-series.pipe';
 import { DataToStackedBarDataPointsPipe } from './pipes/data-to-stacked-bar-data-points.pipe';
+import { CombineRegionsPipe } from './pipes/combine-regions.pipe';
+import { CombineRegionsGreenFossilPipe } from './pipes/combine-regions-green-fossil.pipe';
 
 @NgModule({
   declarations: [
@@ -24,6 +26,8 @@ import { DataToStackedBarDataPointsPipe } from './pipes/data-to-stacked-bar-data
     RegionsToStackedBarCategoriesPipe,
     FuelsToStackedBarSeriesPipe,
     DataToStackedBarDataPointsPipe,
+    CombineRegionsPipe,
+    CombineRegionsGreenFossilPipe,
   ],
   imports: [
     CommonModule,
@@ -42,6 +46,8 @@ import { DataToStackedBarDataPointsPipe } from './pipes/data-to-stacked-bar-data
     RegionsToStackedBarCategoriesPipe,
     DataToStackedBarDataPointsPipe,
     FuelsToStackedBarSeriesPipe,
+    CombineRegionsPipe,
+    CombineRegionsGreenFossilPipe,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
Created new page at the before all regions returned from the API.

Created pipes to combine the datapoints together without having to create a new API. Seperate pipes had to be created for both the normal data points and the green/fossil percentage.