### PR TITLE
Include Unit Of Measure for db size

### DIFF
--- a/service/src/stats/dto/stats.dto.ts
+++ b/service/src/stats/dto/stats.dto.ts
@@ -2,5 +2,5 @@ export class StatsDto {
   recordCount: number;
   minTimestamp: string;
   maxTimestamp: string;
-  databaseSizeMb: number;
+  databaseSize: string;
 }

--- a/service/src/stats/stats.controller.ts
+++ b/service/src/stats/stats.controller.ts
@@ -13,10 +13,10 @@ export class StatsController {
     const minTimestamp = await this.statsService.getMinTimestamp();
     const maxTimestamp = await this.statsService.getMaxTimestamp();
     const recordCount = await this.statsService.getRecordCount();
-    const databaseSizeMb = await this.statsService.getDatabaseSizeMb();
+    const databaseSize = await this.statsService.getDatabaseSize();
 
     return {
-      databaseSizeMb,
+      databaseSize,
       maxTimestamp: maxTimestamp.toISOString(),
       minTimestamp: minTimestamp.toISOString(),
       recordCount,

--- a/service/src/stats/stats.service.ts
+++ b/service/src/stats/stats.service.ts
@@ -12,13 +12,12 @@ export class StatsService {
     private readonly em: EntityManager,
   ) {}
 
-  async getDatabaseSizeMb(): Promise<number> {
+  async getDatabaseSize(): Promise<string> {
     const query = await this.em
       .getKnex()
       .raw("select pg_size_pretty(pg_database_size('postgres')) as size");
 
-    const res = query.rows[0].size as string;
-    return Number(res.slice(0, -3));
+    return query.rows[0].size;
   }
 
   async getMinTimestamp(): Promise<Date> {

--- a/web/src/app/shared/models/stats.ts
+++ b/web/src/app/shared/models/stats.ts
@@ -1,5 +1,5 @@
 export interface Stats {
-  databaseSizeMb: number;
+  databaseSize: string;
   maxTimestamp: string;
   minTimestamp: string;
   recordCount: number;


### PR DESCRIPTION
Change type from number of MB to string that includes UOM. Makes the change to GBs seamless (and this is only meant to be an indicative value).